### PR TITLE
Added support for fasta files

### DIFF
--- a/polish_clusters/args.go
+++ b/polish_clusters/args.go
@@ -20,6 +20,7 @@ type CmdArgs struct {
 	MinimapParams string
 	RaconParams   string
 	SmallMem      bool
+	FromFasta     bool
 }
 
 // Parse command line arguments using the flag package.
@@ -35,6 +36,7 @@ func (a *CmdArgs) Parse() {
 	flag.StringVar(&a.RaconParams, "y", "", "Arguments passed to racon.")
 	flag.StringVar(&a.TempDir, "d", "", "Location of temporary directory.")
 	flag.BoolVar(&a.SmallMem, "m", false, "Do not load all reads in memory (slower).")
+	flag.BoolVar(&a.FromFasta, "f", false, "The BAM file was generated from alignement of a fasta rather than fastq file")
 	flag.BoolVar(&help, "h", false, "Print out help message.")
 	flag.BoolVar(&version, "V", false, "Print out version.")
 

--- a/polish_clusters/main.go
+++ b/polish_clusters/main.go
@@ -25,6 +25,9 @@ func main() {
 	// Initialise output channel for consensus fasta:
 	outChan, flushChan := NewSeqWriterChan(args.ConsOut, "fasta", 100)
 
+	// Command line flag indicates BAM does not contain Phred Scores
+	bamContainsPhred := !args.FromFasta
+
 	var allReads map[string]*Seq
 	if !args.SmallMem {
 		// Read all BAM records if not in low memory mode:
@@ -43,7 +46,7 @@ func main() {
 				reads = getClusterFromReads(readIds, allReads)
 			}
 			// Polish cluster using minimap2 and racon:
-			PolishCluster(clusterId, reads, outChan, args.TempDir, int(args.MaxProcs), args.MinimapParams, args.RaconParams)
+			PolishCluster(clusterId, reads, outChan, args.TempDir, int(args.MaxProcs), args.MinimapParams, args.RaconParams, bamContainsPhred)
 		}
 	}
 


### PR DESCRIPTION
Hi,
this PR addressed issue #25 and adds support for BAM files generated from aligning fasta files rather than fastq.

The functionality is implemented through  a command line option `-f` that instructs `pinfish_polish` to generate sequence files in fasta instead of fastq. I initially considered implementing autodetection of the format, but it would probably mean basing the decision on the first line of the BAM file and it felt a bit hackish and overly complicated.

I've made the PR against master, but I'm happy to rebase on dev if needed.
